### PR TITLE
resuelvo modo dark

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -66,13 +66,21 @@ footer a {
 
 .carousel-caption h3 {
   font-size: 4rem;
+  color: var(--primary-t-color) !important;
 }
 
 .carousel-caption p {
   font-size: 1.5rem;
+  color: var(--primary-t-color)!important;
 }
 
 /* responsive  */
+@media  screen and (max-width: 1440px) {
+  main {
+    min-height: auto!important;
+  }
+}
+
 @media  screen and (max-width: 1199px) {
   .carousel-caption h3 {
     font-size: 32px;
@@ -95,6 +103,10 @@ footer a {
   #mobile-cap {
     top:30%;
   }
+
+  main {
+    min-height: auto!important;
+  }
 }
 
 @media screen and (max-width: 991px) {
@@ -112,6 +124,10 @@ footer a {
   .carousel-caption h3 {
     font-size: 1.8rem;
   }
+
+  main {
+    min-height: auto!important;
+  }
 }
 
 @media screen and (max-width: 575px) {
@@ -126,6 +142,10 @@ footer a {
 
   #mobile-cap {
     top:20%;
+  }
+
+  main {
+    min-height: auto!important;
   }
 }
 


### PR DESCRIPTION
1. se cambia el color de letra de carousel a blanco en modo dark
2. se ajusta el footer en resoluciones inferiores a 1440px para eliminar espacio sobrante

### la letra ahora es visible en modo dark para carousel
![darkmode_1440px](https://github.com/user-attachments/assets/13a68506-1f94-4832-8533-5be5858ceaf6)

### el footer ahora queda pegado al carousel en responsive sin espacios en medio
![iphone](https://github.com/user-attachments/assets/f343cc23-3aa3-4134-90a0-770499a9a079)
